### PR TITLE
Update Developer ID Installer:

### DIFF
--- a/TeamViewer/TeamViewer.download.recipe
+++ b/TeamViewer/TeamViewer.download.recipe
@@ -39,7 +39,7 @@
 				<string>%pathname%/Install TeamViewer.app/Contents/Resources/Install TeamViewer.pkg</string>
 				<key>expected_authority_names</key>
 				<array>
-					<string>Developer ID Installer: TeamViewer GmbH (H7UGFBUGV6)</string>
+					<string>Developer ID Installer: TeamViewer Germany GmbH (H7UGFBUGV6)</string>
 					<string>Developer ID Certification Authority</string>
 					<string>Apple Root CA</string>
 				</array>


### PR DESCRIPTION
Teamviewer Changed there Developer Certificate Label to TeamViewer Germany GmbH (H7UGFBUGV6)

![image](https://user-images.githubusercontent.com/16665557/159588535-ba7c20ab-40ef-43f6-9287-b4f01eeaa14d.png)
